### PR TITLE
Fix missing class and function declaration

### DIFF
--- a/ProcessParser.h
+++ b/ProcessParser.h
@@ -22,25 +22,29 @@
 using namespace std;
 
 class ProcessParser{
-private:
-    std::ifstream stream;
+    private:
+        std::ifstream stream;
+    
     public:
-    static string getCmd(string pid);
-    static vector<string> getPidList();
-    static std::string getVmSize(string pid);
-    static std::string getCpuPercent(string pid);
-    static long int getSysUpTime();
-    static std::string getProcUpTime(string pid);
-    static string getProcUser(string pid);
-    static vector<string> getSysCpuPercent(string coreNumber = "");
-    static float getSysRamPercent();
-    static string getSysKernelVersion();
-    static int getTotalThreads();
-    static int getTotalNumberOfProcesses();
-    static int getNumberOfRunningProcesses();
-    static string getOSName();
-    static std::string PrintCpuStats(std::vector<std::string> values1, std::vector<std::string>values2);
-    static bool isPidExisting(string pid);
+        static string getCmd(string pid);
+        static vector<string> getPidList();
+        static std::string getVmSize(string pid);
+        static std::string getCpuPercent(string pid);
+        static long int getSysUpTime();
+        static std::string getProcUpTime(string pid);
+        static string getProcUser(string pid);
+        static vector<string> getSysCpuPercent(string coreNumber = "");
+        static float getSysActiveCpuTime(vector<string> values);
+        static float getSysIdleCpuTime(vector<string> values);
+        static float getSysRamPercent();
+        static string getSysKernelVersion();
+        static int getTotalThreads();
+        static int getNumberOfCores();
+        static int getTotalNumberOfProcesses();
+        static int getNumberOfRunningProcesses();
+        static string getOSName();
+        static std::string PrintCpuStats(std::vector<std::string> values1, std::vector<std::string>values2);
+        static bool isPidExisting(string pid);
 };
 
 // TODO: Define all of the above functions below:

--- a/SysInfo.h
+++ b/SysInfo.h
@@ -25,7 +25,7 @@ public:
     Initial data for individual cores is set
     System data is set
     */
-        this->getOtherCores(getNumberOfCores());
+        this->getOtherCores(ProcessParser::getNumberOfCores());
         this->setLastCpuMeasures();
         this->setAttributes();
         this-> OSname = ProcessParser::getOSName();


### PR DESCRIPTION
- Add class declaration for `getNumberOfCores` function
- Add missing function declaration in the `ProcessParser` class