### PR TITLE
Fix make build failure

### DIFF
--- a/src/linux_parser.cpp
+++ b/src/linux_parser.cpp
@@ -1,5 +1,6 @@
 #include <dirent.h>
 #include <unistd.h>
+#include <sstream>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
When user run `make build` on this started code, it fails because the `sstream` header is missing, which is used in the source code.