### PR TITLE
Update ncurses_display.cpp

### DIFF
--- a/src/ncurses_display.cpp
+++ b/src/ncurses_display.cpp
@@ -70,7 +70,10 @@ void NCursesDisplay::DisplayProcesses(std::vector<Process>& processes,
   mvwprintw(window, row, command_column, "COMMAND");
   wattroff(window, COLOR_PAIR(2));
   for (int i = 0; i < n; ++i) {
-    mvwprintw(window, ++row, pid_column, to_string(processes[i].Pid()).c_str());
+    // Clear the line
+    mvwprintw(window, ++row, pid_column, (string(window->_maxx-2, ' ').c_str()));
+    
+    mvwprintw(window, row, pid_column, to_string(processes[i].Pid()).c_str());
     mvwprintw(window, row, user_column, processes[i].User().c_str());
     float cpu = processes[i].CpuUtilization() * 100;
     mvwprintw(window, row, cpu_column, to_string(cpu).substr(0, 4).c_str());


### PR DESCRIPTION
Related issue: https://knowledge.udacity.com/questions/160777

Problem:

> Previous no. 1 CPU utilization process has Command = "usr/lib/firefox/firefox"
>New no. 1 CPU utilization process has Command = "./monitor"
>When the new process replaces the old one at the first line of process display, the command column will show "./monitorrefox/firefox", basically the old Command is not cleared properly.

The pull request fixed the issue. Now the new process should show
>"./monitor"
