### PR TITLE
Suppress format-security warning

### DIFF
--- a/src/ncurses_display.cpp
+++ b/src/ncurses_display.cpp
@@ -30,24 +30,24 @@ std::string NCursesDisplay::ProgressBar(float percent) {
 
 void NCursesDisplay::DisplaySystem(System& system, WINDOW* window) {
   int row{0};
-  mvwprintw(window, ++row, 2, ("OS: " + system.OperatingSystem()).c_str());
-  mvwprintw(window, ++row, 2, ("Kernel: " + system.Kernel()).c_str());
+  mvwprintw(window, ++row, 2, "%s", ("OS: " + system.OperatingSystem()).c_str());
+  mvwprintw(window, ++row, 2, "%s", ("Kernel: " + system.Kernel()).c_str());
   mvwprintw(window, ++row, 2, "CPU: ");
   wattron(window, COLOR_PAIR(1));
-  mvwprintw(window, row, 10, "");
-  wprintw(window, ProgressBar(system.Cpu().Utilization()).c_str());
+  mvwprintw(window, row, 10, "%s", "");
+  wprintw(window, "%s",ProgressBar(system.Cpu().Utilization()).c_str());
   wattroff(window, COLOR_PAIR(1));
   mvwprintw(window, ++row, 2, "Memory: ");
   wattron(window, COLOR_PAIR(1));
-  mvwprintw(window, row, 10, "");
-  wprintw(window, ProgressBar(system.MemoryUtilization()).c_str());
+  mvwprintw(window, row, 10, "%s", "");
+  wprintw(window, "%s",ProgressBar(system.MemoryUtilization()).c_str());
   wattroff(window, COLOR_PAIR(1));
-  mvwprintw(window, ++row, 2,
+  mvwprintw(window, ++row, 2, "%s",
             ("Total Processes: " + to_string(system.TotalProcesses())).c_str());
   mvwprintw(
-      window, ++row, 2,
+      window, ++row, 2, "%s",
       ("Running Processes: " + to_string(system.RunningProcesses())).c_str());
-  mvwprintw(window, ++row, 2,
+  mvwprintw(window, ++row, 2, "%s",
             ("Up Time: " + Format::ElapsedTime(system.UpTime())).c_str());
   wrefresh(window);
 }
@@ -74,14 +74,14 @@ void NCursesDisplay::DisplayProcesses(std::vector<Process>& processes,
     // Clear the line
     mvwprintw(window, ++row, pid_column, (string(window->_maxx-2, ' ').c_str()));
     
-    mvwprintw(window, row, pid_column, to_string(processes[i].Pid()).c_str());
-    mvwprintw(window, row, user_column, processes[i].User().c_str());
+    mvwprintw(window, row, pid_column, "%s", to_string(processes[i].Pid()).c_str());
+    mvwprintw(window, row, user_column, "%s", processes[i].User().c_str());
     float cpu = processes[i].CpuUtilization() * 100;
-    mvwprintw(window, row, cpu_column, to_string(cpu).substr(0, 4).c_str());
-    mvwprintw(window, row, ram_column, processes[i].Ram().c_str());
-    mvwprintw(window, row, time_column,
+    mvwprintw(window, row, cpu_column, "%s", to_string(cpu).substr(0, 4).c_str());
+    mvwprintw(window, row, ram_column, "%s", processes[i].Ram().c_str());
+    mvwprintw(window, row, time_column, "%s",
               Format::ElapsedTime(processes[i].UpTime()).c_str());
-    mvwprintw(window, row, command_column,
+    mvwprintw(window, row, command_column, "%s",
               processes[i].Command().substr(0, window->_maxx - 46).c_str());
   }
 }

--- a/src/ncurses_display.cpp
+++ b/src/ncurses_display.cpp
@@ -35,12 +35,12 @@ void NCursesDisplay::DisplaySystem(System& system, WINDOW* window) {
   mvwprintw(window, ++row, 2, "CPU: ");
   wattron(window, COLOR_PAIR(1));
   mvwprintw(window, row, 10, "%s", "");
-  wprintw(window, "%s",ProgressBar(system.Cpu().Utilization()).c_str());
+  wprintw(window, "%s", ProgressBar(system.Cpu().Utilization()).c_str());
   wattroff(window, COLOR_PAIR(1));
   mvwprintw(window, ++row, 2, "Memory: ");
   wattron(window, COLOR_PAIR(1));
   mvwprintw(window, row, 10, "%s", "");
-  wprintw(window, "%s",ProgressBar(system.MemoryUtilization()).c_str());
+  wprintw(window, "%s", ProgressBar(system.MemoryUtilization()).c_str());
   wattroff(window, COLOR_PAIR(1));
   mvwprintw(window, ++row, 2, "%s",
             ("Total Processes: " + to_string(system.TotalProcesses())).c_str());


### PR DESCRIPTION
The project rubric requests not to generate any warnings during the build process, so the starter code should not raise any warnings. However, it does raise the following warnings:
```
src/ncurses_display.cpp:33:12: warning: format not a string literal and no format arguments [-Wformat-security]
   33 |   mvwprintw(window, ++row, 2, ("OS: " + system.OperatingSystem()).c_str());
      |   ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
This PR uses the methods in [this thread](https://github.com/spdk/spdk/issues/2237) to suppress the above warnings.